### PR TITLE
Tweaks to adding thresholds for per 100000 population

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,7 @@ verify_ssl = true
 requests = "*"
 boto3 = "*"
 pandas = "*"
+xlrd = "*"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "dc63b566a5acc289750ccad11b67964a2a1c5c4409c23d1703b39fccf54fc71d"
+            "sha256": "226646f931148d390215864bb6a1aadfa0ac26154860b9614b8b415390832d3c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,19 +18,19 @@
     "default": {
         "boto3": {
             "hashes": [
-                "sha256:06d8dca85a0bb66b7bf2721745895d44691c78dbe7eb3b146702aff85e34af34",
-                "sha256:1f02cd513b130f9cd86c99836de6a0a5f78ea55110bdbc9011d9d78ff0fd3204"
+                "sha256:6180272094030bda3ee5c242881892cd3d9d19c05cb513945f530e396c7de1e4",
+                "sha256:95d814d16fe55ae55e1e4a3db248596f9647a0c42f4796c6e05be0bfaffb1830"
             ],
             "index": "pypi",
-            "version": "==1.17.89"
+            "version": "==1.17.94"
         },
         "botocore": {
             "hashes": [
-                "sha256:ce0fa8bc260ad187824052805d224cee239d953bb4bfb1e52cf35ad79481b316",
-                "sha256:e112f9a45db1c5a42f787e4b228a35da6e823bcba70f43f43005b4fb58066446"
+                "sha256:60a382a5b2f7d77b1b575d54fba819097526e3fdd0f3004f4d1142d50af0d642",
+                "sha256:ba8a7951be535e25219a82dea15c30d7bdf0c51e7c1623c3306248493c1616ac"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.20.89"
+            "version": "==1.20.94"
         },
         "certifi": {
             "hashes": [
@@ -160,6 +160,14 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==1.26.5"
+        },
+        "xlrd": {
+            "hashes": [
+                "sha256:6a33ee89877bd9abc1158129f6e94be74e2679636b8a205b43b85206c3f0bbdd",
+                "sha256:f72f148f54442c6b056bf931dbc34f986fd0c3b0b6b5a58d013c9aef274d0c88"
+            ],
+            "index": "pypi",
+            "version": "==2.0.1"
         }
     },
     "develop": {}

--- a/src/main.py
+++ b/src/main.py
@@ -12,7 +12,7 @@ METRICS_BUCKET = "investigations-data-dev"
 METRICS_KEY = "uk-coronavirus-data-alerts/metrics.json"
 
 PERCENTAGE_CHANGE_THRESHOLD = 100.0
-CASES_PER_100000_POPULATION_THRESHOLD = 50.0
+CASES_PER_100000_POPULATION_THRESHOLD = 100.0
 
 NOTIFY_EMAILS = os.environ.get("NOTIFY_EMAIL_ADDRESSES")
 if NOTIFY_EMAILS is None:
@@ -70,8 +70,8 @@ def population_for_area(populations_df, area_name, area_code):
     try:
         area_population = populations_df.at[area_code, "All ages"]
         return area_population
-    except KeyError:
-        print(f"Error getting population for area '{area_name}', area code {area_code} not found.", file=sys.stderr)
+    except KeyError as e:
+        print(f"Error getting population for area '{area_name}', area code {area_code} not found.", e, file=sys.stderr)
 
 
 def get_cases_per_100000(cases, populations_df, metric_df, area_name):
@@ -79,8 +79,8 @@ def get_cases_per_100000(cases, populations_df, metric_df, area_name):
     try:
         area_population = population_for_area(populations_df, area_name, area_code)
         return (cases / area_population) * 100000
-    except TypeError:
-        print(f"Cannot calculate population for area ${area_name}", file=sys.stderr)
+    except TypeError as e:
+        print(f"Cannot calculate population for area ${area_name}", e, file=sys.stderr)
 
 
 # We want 7 days inclusive of the latest


### PR DESCRIPTION
After speaking to Pamela, she would like to up the threshold for alerting on cases per 100,000 to 100 from 50. Here I also include the xlrd dependency needed to read the .xml file (oops!) and log the error as well as an error message for if/when we fail to look up an area by area code.