### PR TITLE
Increase timeout to 120s

### DIFF
--- a/src/aws-infra.ts
+++ b/src/aws-infra.ts
@@ -35,7 +35,7 @@ class UKCoronavirusDataAlertsStack extends GuStack {
                     description: 'Check UK coronavirus data every weekday at 8AM'
                 }
             ],
-            timeout: Duration.minutes(1)
+            timeout: Duration.minutes(2)
         });
 
         lambda.addToRolePolicy(new PolicyStatement({


### PR DESCRIPTION
Since merging PR #11 the lambda times out after 60s.

Here we up the timeout to 120s, we have tested this change and have found that this gives the lambda enough time to complete (~75s):

![image](https://user-images.githubusercontent.com/9820960/127679379-78b47640-dfe4-416e-8b24-2931ba641428.png)
