### PR TITLE
Bump the version of the guardian cdk library

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "uk-coronavirus-data-alerts",
   "version": "0.0.1",
   "dependencies": {
-    "@guardian/cdk": "guardian/cdk#make-it-possible-to-define-multiple-lambdas-per-stack",
+    "@guardian/cdk": "25.0.1",
     "@guardian/node-riffraff-artifact": "^0.2.1",
     "@tsconfig/node14": "^1.0.0",
-    "cdk": "1.120.0",
+    "cdk": "1.122.0",
     "ts-node": "^9.1.1",
     "typescript": "^4.2.4"
   },

--- a/src/main.py
+++ b/src/main.py
@@ -318,7 +318,7 @@ def check_last_two_weeks_of_metrics():
         else:
             subject = "[UK Coronavirus Data Alert] New metrics available. NOT FOR PUBLISH - most recent, unverified metrics"
             email_type_text = "<p>WARNING: The period represented is the 7 days ending with the latest day for which data is available. This is different from the government dashboard which " \
-                "looks at the period ending five days before the website was last updated.</p>"
+                "looks at the period ending 5 days before the website was last updated.</p>"
 
         body = textwrap.dedent(f"""
             {email_type_text}


### PR DESCRIPTION
 This release includes [our fix](https://github.com/guardian/cdk/pull/781) to make it possible to define multiple lambdas per stack.

I have successfully deployed this branch and tested that a run of the lambda results in an email.


