### PR TITLE
Admissions and cases by nhs trust

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -312,7 +312,7 @@ def compare_available_metrics():
 
 
 def check_last_two_weeks_of_metrics():
-    hospitalizations_thresholds = {"percentage_change_threshold": 25.0, "metric_value_threshold": 0}
+    hospitalizations_thresholds = {"percentage_change_threshold": 50.0, "metric_value_threshold": 30}
     cases_thresholds = {"percentage_change_threshold": 50.0, "metric_value_per_100000_threshold": 50.0}
     all_data = [
         get_areas_above_thresholds("ltla", "newCasesBySpecimenDate", cases_thresholds, 'sum'),


### PR DESCRIPTION
## What does this change?
1. Removes new admissions data from email alert as it's no longer needed
2. Move from reporting hospitalisations data by region to reporting by NHS trust
3.  Introduce "metric value threshold" for hospitalisations; regardless of percentage change we won't include an NHS trust in the report unless the number of hospitalisations exceeds 30.
4. For hospitalisations, lower percentage change threshold from 100% to 50%

## How to test

All four of the above changes can be tested by running main.py locally:

1. Run main.py to confirm that new admissions are no longer reported.

2. Compare data for individual trusts to the [UK Coronavirus Dashboard](https://coronavirus.data.gov.uk/details/healthcare)

<img width="1087" alt="Screenshot 2021-10-04 at 15 58 28" src="https://user-images.githubusercontent.com/17057932/135885098-57bf2f7c-f80e-4388-8ff7-733162047df5.png">

<img width="1570" alt="Screenshot 2021-10-04 at 17 00 41" src="https://user-images.githubusercontent.com/17057932/135884675-f8213178-99b1-409e-bf28-d354fdae28f3.png">

3. and 4. Compare print statements in `get_areas_above_thresholds ` before and after filtering. Trusts that exceed the percentage change threshold but do not exceed the metric value threshold are not included in the final report.