### PR TITLE
Increase the new cases alerting threshold back to what it was

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -217,7 +217,7 @@ def area_code_for_area(metric_df, area_name):
 
 
 def get_areas_above_thresholds(area_type, metric_name, aggregation_function):
-    thresholds = {"percentage_change_threshold": 50.0, "new_cases_per_100000_threshold": 50.0, "hospital_cases_threshold": 20}
+    thresholds = {"percentage_change_threshold": 50.0, "new_cases_per_100000_threshold": 100.0, "hospital_cases_threshold": 20}
     url = f"https://api.coronavirus.data.gov.uk/v2/data?areaType={area_type}&metric={metric_name}&format=csv"
     df = percentage_changes(url, metric_name, aggregation_function)
 


### PR DESCRIPTION
PR #17 lowered the new cases alerting threshold from 100% to 50%. This led to a rather long list of areas being flagged in today's email:

![image](https://user-images.githubusercontent.com/9820960/137749454-8677192f-b3b9-4809-823f-83c1c807053f.png)

This change takes the threshold back to 100%.

Apologies, I should have spotted this when reviewing.
